### PR TITLE
Fetches regional or global secrets 

### DIFF
--- a/Abhiram.Secrets.Providers/Abhiram.Secrets.Providers.csproj
+++ b/Abhiram.Secrets.Providers/Abhiram.Secrets.Providers.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>        
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Abhiram.Secrets.Providers</PackageId>
-        <Version>2.0.0</Version>
+        <Version>2.1.0</Version>
         <Authors>Abhiram</Authors>
         <Description>A flexible and extensible secret management for .NET applications, supporting environment-based secret resolution from local environment variables, Google Cloud Secret Manager, Azure Key Vault, and AWS Secrets Manager.</Description>
         <RepositoryUrl>https://github.com/Abhiram13/Abhiram.Nuget.Libraries</RepositoryUrl>

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,7 @@
+![Nuget](https://img.shields.io/badge/Nuget-004880?logo=nuget&logoColor=white)
+
+![Abhiram.Abstractions.Logging](https://img.shields.io/badge/Abhiram.Abstractions.Logging-2.0.0-blue)
+
+![Abhiram.Extensions.Dotenv](https://img.shields.io/badge/Abhiram.Extensions.Dotenv-1.1.1-green)
+
+![Abhiram.Secrets.Providers](https://img.shields.io/badge/Abhiram.Secrets.Providers-2.0.0-orange)


### PR DESCRIPTION
This update contains the following:
- Fetches regional secrets first if region id exists or fetches from global secrets from GCP secret manager
- Added badges for all packages in ReadMe